### PR TITLE
Fix malformed URL error when relative path contains colon in first segment

### DIFF
--- a/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
@@ -1431,21 +1431,85 @@ public final class RequestFactoryTest {
 
   @Test
   public void getWithColonInRelativeUrlFirstSegment() {
-    // Regression test for https://github.com/square/retrofit/issues/3080
-    // A colon in the first segment of a relative URL (before the first slash) can be
-    // misinterpreted as a URL scheme separator. This test ensures such colons are encoded.
     class Example {
       @PUT("user:email={email}/login") //
-      Call<ResponseBody> method(@Path("email") String email, @Body String pass) {
+      Call<ResponseBody> method(@Path("email") String email) {
         return null;
       }
     }
 
-    Request request = buildRequest(Example.class, "me@test.com", "password");
+    Retrofit.Builder retrofitBuilder = new Retrofit.Builder().baseUrl("http://example.com/api/");
+    Request request = buildRequest(Example.class, retrofitBuilder, "me@test.com");
     assertThat(request.method()).isEqualTo("PUT");
-    // Colon in first path segment encoded as %3A to prevent scheme misinterpretation
     assertThat(request.url().toString())
-        .isEqualTo("http://example.com/user%3Aemail=me@test.com/login");
+        .isEqualTo("http://example.com/api/user:email=me@test.com/login");
+  }
+
+  @Test
+  public void getWithExplicitDotSegmentAndColonInRelativeUrlFirstSegment() {
+    class Example {
+      @PUT("./user:email={email}/login") //
+      Call<ResponseBody> method(@Path("email") String email) {
+        return null;
+      }
+    }
+
+    Request request = buildRequest(Example.class, "me@test.com");
+    assertThat(request.url().toString())
+        .isEqualTo("http://example.com/user:email=me@test.com/login");
+  }
+
+  @Test
+  public void explicitDotSegmentStillRejectsPathParameterTraversal() {
+    class Example {
+      @GET("./{path}") //
+      Call<ResponseBody> method(@Path(value = "path", encoded = true) String path) {
+        return null;
+      }
+    }
+
+    assertMalformedRequest(Example.class, "../accounts");
+  }
+
+  @Test
+  public void getWithColonInRelativeUrlFirstSegmentAndQuery() {
+    class Example {
+      @GET("user:email={email}/login") //
+      Call<ResponseBody> method(@Path("email") String email, @Query("redirect") String redirect) {
+        return null;
+      }
+    }
+
+    Request request = buildRequest(Example.class, "me@test.com", "next:step");
+    assertThat(request.url().toString())
+        .isEqualTo("http://example.com/user:email=me@test.com/login?redirect=next%3Astep");
+  }
+
+  @Test
+  public void getWithPathParamBeforeColonInFirstSegment() {
+    class Example {
+      @GET("{type}:items") //
+      Call<ResponseBody> method(@Path("type") String type) {
+        return null;
+      }
+    }
+
+    Request request = buildRequest(Example.class, "user");
+    assertThat(request.url().toString()).isEqualTo("http://example.com/user:items");
+  }
+
+  @Test
+  public void colonInQueryAndFragmentDoesNotDisambiguatePath() {
+    class Example {
+      @GET("{resource}?filter=kind:value#section:details") //
+      Call<ResponseBody> method(@Path("resource") String resource) {
+        return null;
+      }
+    }
+
+    Request request = buildRequest(Example.class, "users");
+    assertThat(request.url().toString())
+        .isEqualTo("http://example.com/users?filter=kind:value#section:details");
   }
 
   @Test
@@ -1650,6 +1714,20 @@ public final class RequestFactoryTest {
     assertThat(request.headers().size()).isEqualTo(0);
     assertThat(request.url().toString()).isEqualTo("http://example2.com/foo/bar/");
     assertThat(request.body()).isNull();
+  }
+
+  @Test
+  public void getAbsoluteUrlWithColonAndPathParameter() {
+    class Example {
+      @GET("https://example2.com/user:email={email}/login") //
+      Call<ResponseBody> method(@Path("email") String email) {
+        return null;
+      }
+    }
+
+    Request request = buildRequest(Example.class, "me@test.com");
+    assertThat(request.url().toString())
+        .isEqualTo("https://example2.com/user:email=me@test.com/login");
   }
 
   @Test
@@ -3221,6 +3299,24 @@ public final class RequestFactoryTest {
   }
 
   @Test
+  public void malformedAnnotationOpaqueUrlThrows() {
+    class Example {
+      @GET("mailto:user@example.com")
+      Call<ResponseBody> get() {
+        return null;
+      }
+    }
+    try {
+      buildRequest(Example.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo("Malformed URL. Base: http://example.com/, Relative: mailto:user@example.com");
+    }
+  }
+
+  @Test
   public void malformedParameterRelativeUrlThrows() {
     class Example {
       @GET
@@ -3235,6 +3331,24 @@ public final class RequestFactoryTest {
       assertThat(e)
           .hasMessageThat()
           .isEqualTo("Malformed URL. Base: http://example.com/, Relative: ftp://example.org");
+    }
+  }
+
+  @Test
+  public void malformedParameterOpaqueUrlThrows() {
+    class Example {
+      @GET
+      Call<ResponseBody> get(@Url String relativeUrl) {
+        return null;
+      }
+    }
+    try {
+      buildRequest(Example.class, "mailto:user@example.com");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo("Malformed URL. Base: http://example.com/, Relative: mailto:user@example.com");
     }
   }
 

--- a/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
@@ -1411,6 +1411,44 @@ public final class RequestFactoryTest {
   }
 
   @Test
+  public void getWithPathAndQueryColonParam() {
+    class Example {
+      @GET("/foo/bar/{ping}/") //
+      Call<ResponseBody> method(@Path("ping") String ping, @Query("kit") String kit) {
+        return null;
+      }
+    }
+
+    Request request = buildRequest(Example.class, "pong:colon", "kat:colon");
+    assertThat(request.method()).isEqualTo("GET");
+    assertThat(request.headers().size()).isEqualTo(0);
+    // Colon in path segment after first slash is not encoded (safe in that position).
+    // Colon in query is encoded by OkHttp.
+    assertThat(request.url().toString())
+        .isEqualTo("http://example.com/foo/bar/pong:colon/?kit=kat%3Acolon");
+    assertThat(request.body()).isNull();
+  }
+
+  @Test
+  public void getWithColonInRelativeUrlFirstSegment() {
+    // Regression test for https://github.com/square/retrofit/issues/3080
+    // A colon in the first segment of a relative URL (before the first slash) can be
+    // misinterpreted as a URL scheme separator. This test ensures such colons are encoded.
+    class Example {
+      @PUT("user:email={email}/login") //
+      Call<ResponseBody> method(@Path("email") String email, @Body String pass) {
+        return null;
+      }
+    }
+
+    Request request = buildRequest(Example.class, "me@test.com", "password");
+    assertThat(request.method()).isEqualTo("PUT");
+    // Colon in first path segment encoded as %3A to prevent scheme misinterpretation
+    assertThat(request.url().toString())
+        .isEqualTo("http://example.com/user%3Aemail=me@test.com/login");
+  }
+
+  @Test
   public void getWithQueryParamList() {
     class Example {
       @GET("/foo/bar/") //

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -35,56 +35,6 @@ final class RequestBuilder {
   private static final String PATH_SEGMENT_ALWAYS_ENCODE_SET = " \"<>^`{}|\\?#";
 
   /**
-   * Encodes colons in the first path segment of a relative URL to prevent them from being
-   * misinterpreted as URL scheme separators. Per RFC 3986 section 4.2, a colon in the first segment
-   * of a relative-path reference can be mistaken for a scheme name.
-   *
-   * <p>This method only encodes colons in relative paths. If the URL looks like it has a scheme
-   * (e.g., starts with "http://", "https://"), it is returned unchanged.
-   */
-  private static String encodeColonInFirstPathSegment(String relativeUrl) {
-    if (relativeUrl.isEmpty() || relativeUrl.charAt(0) == '/') {
-      // Absolute path or empty, no encoding needed.
-      return relativeUrl;
-    }
-
-    int firstColon = relativeUrl.indexOf(':');
-    if (firstColon == -1) {
-      // No colon, nothing to encode.
-      return relativeUrl;
-    }
-
-    int firstSlash = relativeUrl.indexOf('/');
-    if (firstSlash != -1 && firstSlash < firstColon) {
-      // Colon is after the first slash, so it's not in the first segment.
-      return relativeUrl;
-    }
-
-    // Check if this looks like a URL scheme (scheme followed by "://").
-    // Per RFC 3986, a scheme is followed by ":" and authority starts with "//".
-    if (relativeUrl.length() > firstColon + 2
-        && relativeUrl.charAt(firstColon + 1) == '/'
-        && relativeUrl.charAt(firstColon + 2) == '/') {
-      // This looks like a scheme (e.g., "http://..."), don't encode.
-      return relativeUrl;
-    }
-
-    // Encode all colons in the first segment (before the first slash or end of string).
-    int endOfFirstSegment = firstSlash == -1 ? relativeUrl.length() : firstSlash;
-    StringBuilder encoded = new StringBuilder();
-    for (int i = 0; i < endOfFirstSegment; i++) {
-      char c = relativeUrl.charAt(i);
-      if (c == ':') {
-        encoded.append("%3A");
-      } else {
-        encoded.append(c);
-      }
-    }
-    encoded.append(relativeUrl.substring(endOfFirstSegment));
-    return encoded.toString();
-  }
-
-  /**
    * Matches strings that contain {@code .} or {@code ..} as a complete path segment. This also
    * matches dots in their percent-encoded form, {@code %2E}.
    *
@@ -102,6 +52,7 @@ final class RequestBuilder {
   private final String method;
 
   private final HttpUrl baseUrl;
+  private final boolean hasPathParameters;
   private @Nullable String relativeUrl;
   private @Nullable HttpUrl.Builder urlBuilder;
 
@@ -118,6 +69,7 @@ final class RequestBuilder {
       String method,
       HttpUrl baseUrl,
       @Nullable String relativeUrl,
+      boolean hasPathParameters,
       @Nullable Headers headers,
       @Nullable MediaType contentType,
       boolean hasBody,
@@ -125,6 +77,7 @@ final class RequestBuilder {
       boolean isMultipart) {
     this.method = method;
     this.baseUrl = baseUrl;
+    this.hasPathParameters = hasPathParameters;
     this.relativeUrl = relativeUrl;
     this.requestBuilder = new Request.Builder();
     this.contentType = contentType;
@@ -148,6 +101,40 @@ final class RequestBuilder {
 
   void setRelativeUrl(Object relativeUrl) {
     this.relativeUrl = relativeUrl.toString();
+  }
+
+  private String disambiguateRelativeUrl(String relativeUrl) {
+    if (!hasPathParameters || relativeUrl.isEmpty() || relativeUrl.charAt(0) == '/') {
+      return relativeUrl;
+    }
+
+    int firstColon = relativeUrl.indexOf(':');
+    if (firstColon == -1) {
+      return relativeUrl;
+    }
+
+    int firstSegmentEnd = relativeUrl.length();
+    int firstSlash = relativeUrl.indexOf('/');
+    if (firstSlash != -1) {
+      firstSegmentEnd = firstSlash;
+    }
+    int queryStart = relativeUrl.indexOf('?');
+    if (queryStart != -1 && queryStart < firstSegmentEnd) {
+      firstSegmentEnd = queryStart;
+    }
+    int fragmentStart = relativeUrl.indexOf('#');
+    if (fragmentStart != -1 && fragmentStart < firstSegmentEnd) {
+      firstSegmentEnd = fragmentStart;
+    }
+    if (firstColon >= firstSegmentEnd
+        || relativeUrl.regionMatches(true, 0, "http:", 0, 5)
+        || relativeUrl.regionMatches(true, 0, "https:", 0, 6)
+        || relativeUrl.startsWith("://", firstColon)) {
+      return relativeUrl;
+    }
+
+    // RFC 3986 section 4.2 uses a leading dot-segment to distinguish this from a URI scheme.
+    return "./" + relativeUrl;
   }
 
   void addHeader(String name, String value, boolean allowUnsafeNonAsciiValues) {
@@ -175,7 +162,9 @@ final class RequestBuilder {
     }
     String replacement = canonicalizeForPath(value, encoded);
     String newRelativeUrl = relativeUrl.replace("{" + name + "}", replacement);
-    if (PATH_TRAVERSAL.matcher(newRelativeUrl).matches()) {
+    String traversalCandidate =
+        relativeUrl.startsWith("./") ? newRelativeUrl.substring(2) : newRelativeUrl;
+    if (PATH_TRAVERSAL.matcher(traversalCandidate).matches()) {
       throw new IllegalArgumentException(
           "@Path parameters shouldn't perform path traversal ('.' or '..'): " + value);
     }
@@ -237,8 +226,7 @@ final class RequestBuilder {
   void addQueryParam(String name, @Nullable String value, boolean encoded) {
     if (relativeUrl != null) {
       // Do a one-time combination of the built relative URL and the base URL.
-      String encodedRelativeUrl = encodeColonInFirstPathSegment(relativeUrl);
-      urlBuilder = baseUrl.newBuilder(encodedRelativeUrl);
+      urlBuilder = baseUrl.newBuilder(disambiguateRelativeUrl(relativeUrl));
       if (urlBuilder == null) {
         throw new IllegalArgumentException(
             "Malformed URL. Base: " + baseUrl + ", Relative: " + relativeUrl);
@@ -290,8 +278,7 @@ final class RequestBuilder {
     } else {
       // No query parameters triggered builder creation, just combine the relative URL and base URL.
       //noinspection ConstantConditions Non-null if urlBuilder is null.
-      String encodedRelativeUrl = encodeColonInFirstPathSegment(relativeUrl);
-      url = baseUrl.resolve(encodedRelativeUrl);
+      url = baseUrl.resolve(disambiguateRelativeUrl(relativeUrl));
       if (url == null) {
         throw new IllegalArgumentException(
             "Malformed URL. Base: " + baseUrl + ", Relative: " + relativeUrl);

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -35,6 +35,56 @@ final class RequestBuilder {
   private static final String PATH_SEGMENT_ALWAYS_ENCODE_SET = " \"<>^`{}|\\?#";
 
   /**
+   * Encodes colons in the first path segment of a relative URL to prevent them from being
+   * misinterpreted as URL scheme separators. Per RFC 3986 section 4.2, a colon in the first segment
+   * of a relative-path reference can be mistaken for a scheme name.
+   *
+   * <p>This method only encodes colons in relative paths. If the URL looks like it has a scheme
+   * (e.g., starts with "http://", "https://"), it is returned unchanged.
+   */
+  private static String encodeColonInFirstPathSegment(String relativeUrl) {
+    if (relativeUrl.isEmpty() || relativeUrl.charAt(0) == '/') {
+      // Absolute path or empty, no encoding needed.
+      return relativeUrl;
+    }
+
+    int firstColon = relativeUrl.indexOf(':');
+    if (firstColon == -1) {
+      // No colon, nothing to encode.
+      return relativeUrl;
+    }
+
+    int firstSlash = relativeUrl.indexOf('/');
+    if (firstSlash != -1 && firstSlash < firstColon) {
+      // Colon is after the first slash, so it's not in the first segment.
+      return relativeUrl;
+    }
+
+    // Check if this looks like a URL scheme (scheme followed by "://").
+    // Per RFC 3986, a scheme is followed by ":" and authority starts with "//".
+    if (relativeUrl.length() > firstColon + 2
+        && relativeUrl.charAt(firstColon + 1) == '/'
+        && relativeUrl.charAt(firstColon + 2) == '/') {
+      // This looks like a scheme (e.g., "http://..."), don't encode.
+      return relativeUrl;
+    }
+
+    // Encode all colons in the first segment (before the first slash or end of string).
+    int endOfFirstSegment = firstSlash == -1 ? relativeUrl.length() : firstSlash;
+    StringBuilder encoded = new StringBuilder();
+    for (int i = 0; i < endOfFirstSegment; i++) {
+      char c = relativeUrl.charAt(i);
+      if (c == ':') {
+        encoded.append("%3A");
+      } else {
+        encoded.append(c);
+      }
+    }
+    encoded.append(relativeUrl.substring(endOfFirstSegment));
+    return encoded.toString();
+  }
+
+  /**
    * Matches strings that contain {@code .} or {@code ..} as a complete path segment. This also
    * matches dots in their percent-encoded form, {@code %2E}.
    *
@@ -187,7 +237,8 @@ final class RequestBuilder {
   void addQueryParam(String name, @Nullable String value, boolean encoded) {
     if (relativeUrl != null) {
       // Do a one-time combination of the built relative URL and the base URL.
-      urlBuilder = baseUrl.newBuilder(relativeUrl);
+      String encodedRelativeUrl = encodeColonInFirstPathSegment(relativeUrl);
+      urlBuilder = baseUrl.newBuilder(encodedRelativeUrl);
       if (urlBuilder == null) {
         throw new IllegalArgumentException(
             "Malformed URL. Base: " + baseUrl + ", Relative: " + relativeUrl);
@@ -239,7 +290,8 @@ final class RequestBuilder {
     } else {
       // No query parameters triggered builder creation, just combine the relative URL and base URL.
       //noinspection ConstantConditions Non-null if urlBuilder is null.
-      url = baseUrl.resolve(relativeUrl);
+      String encodedRelativeUrl = encodeColonInFirstPathSegment(relativeUrl);
+      url = baseUrl.resolve(encodedRelativeUrl);
       if (url == null) {
         throw new IllegalArgumentException(
             "Malformed URL. Base: " + baseUrl + ", Relative: " + relativeUrl);

--- a/retrofit/src/main/java/retrofit2/RequestFactory.java
+++ b/retrofit/src/main/java/retrofit2/RequestFactory.java
@@ -72,6 +72,7 @@ final class RequestFactory {
   private final HttpUrl baseUrl;
   final String httpMethod;
   private final @Nullable String relativeUrl;
+  private final boolean hasPathParameters;
   private final @Nullable Headers headers;
   private final @Nullable MediaType contentType;
   private final boolean hasBody;
@@ -86,6 +87,8 @@ final class RequestFactory {
     baseUrl = builder.retrofit.baseUrl;
     httpMethod = builder.httpMethod;
     relativeUrl = builder.relativeUrl;
+    hasPathParameters =
+        builder.relativeUrlParamNames != null && !builder.relativeUrlParamNames.isEmpty();
     headers = builder.headers;
     contentType = builder.contentType;
     hasBody = builder.hasBody;
@@ -114,6 +117,7 @@ final class RequestFactory {
             httpMethod,
             baseUrl,
             relativeUrl,
+            hasPathParameters,
             headers,
             contentType,
             hasBody,


### PR DESCRIPTION
## Summary

This change addresses #3080, where Retrofit rejects a relative endpoint whose first path segment contains a colon.

For example:

```java
@PUT("user:email={email}/login")
Call<ResponseBody> login(@Path("email") String email);
```

After substituting the path parameter, Retrofit asks OkHttp to resolve:

```text
user:email=me@test.com/login
```

URI parsers interpret `user:` as a scheme rather than part of a relative path, so OkHttp cannot resolve it against the HTTP base URL.

RFC 3986 recommends prefixing this kind of relative path with `./`. The implementation now performs that disambiguation internally for annotation URLs containing `@Path` parameters:

```text
user:email=me@test.com/login
./user:email=me@test.com/login
```

The `./` segment disappears during URL resolution. With a base URL of `http://example.com/api/`, the final URL is:

```text
http://example.com/api/user:email=me@test.com/login
```

The colon remains literal. It is not changed to `%3A`.

## Implementation

`RequestFactory` records whether the annotation URL contains path parameters and passes that information to `RequestBuilder`.

Before resolving a templated relative URL, `RequestBuilder` checks whether its first path segment contains a colon. If it does, Retrofit prefixes the URL with `./`.

This happens in both request-building paths:

- Direct URL resolution when no query parameters are added.
- `HttpUrl.Builder` creation when Retrofit adds query parameters.

The change also permits users to write the RFC form explicitly:

```java
@PUT("./user:email={email}/login")
```

The path traversal check ignores this static leading `./`, but it continues rejecting `.` or `..` supplied through an `@Path` value.

## Preserved behavior

The disambiguation does not apply to:

- Dynamic `@Url` values.
- Absolute HTTP or HTTPS annotation URLs.
- URLs beginning with `/`.
- Colons after the first path segment.
- Colons in the query or fragment.

Base URL path segments are preserved.

## Open question

The string itself cannot always reveal the caller’s intent.

For example:

```java
@GET("mailto:{value}")
```

Because it contains an `@Path` parameter, the current implementation treats this as a relative HTTP path and resolves it as:

```text
http://example.com/mailto:user@example.com
```

Without a path parameter, `mailto:user@example.com` remains an unsupported URI and fails.

The design choice is whether Retrofit should infer that templated scheme-like strings are relative paths, or require callers to write the unambiguous `./` prefix themselves. Requiring `./` is stricter and follows RFC 3986 directly, but it would not make the original annotation from #3080 work unchanged.

## Validation

The tests cover literal colon preservation, base URL paths, added query parameters, explicit `./`, traversal rejection, absolute URLs, and query or fragment boundaries.

The following checks pass:

```bash
./gradlew \
  :retrofit:spotlessJavaCheck \
  :retrofit:java-test:spotlessJavaCheck \
  :retrofit:java-test:testJdk21
```