### PR TITLE
Use lysine-dev in build workflow conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    if: github.repository == 'square/retrofit' && github.ref == 'refs/heads/trunk'
+    if: github.repository == 'lysine-dev/retrofit' && github.ref == 'refs/heads/trunk'
     needs:
       - final-status
 


### PR DESCRIPTION
build.yml still checks for square/retrofit, so the publish job has been skipped since the rename.
