### PR TITLE
Grant write permission for publish jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,9 @@ jobs:
     if: github.repository == 'lysine-dev/retrofit' && github.ref == 'refs/heads/trunk'
     needs:
       - final-status
+    permissions:
+      contents: write
+      actions: read
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -145,5 +148,5 @@ jobs:
         with:
           branch: site
           folder: website/dist
-          target_folder: latest
+          target-folder: latest
           clean: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Snapshot and release site pushes fail with 403 because the default token is read-only. Added write permission to the publish jobs. Also, added `actions: read` to snapshot publish so it can still download the website artifact.

Renamed `target_folder` to `target-folder`. The publish job warns that `target_folder` is unexpected; without that, snapshot docs would deploy to the site root and overwrite the release site.

https://github.com/lysine-dev/retrofit/actions/runs/32546665551/job/96966776463

Fixes #4751
