### PR TITLE
Preserve RequestBody flags when overriding Content-Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 **Fixed**
 
- - Nothing yet!
+ - Preserve `RequestBody.isOneShot()` and `isDuplex()` when overriding the `Content-Type` header.
 
 
 ## [3.0.0] - 2025-05-15

--- a/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
+++ b/retrofit/java-test/src/test/java/retrofit2/RequestFactoryTest.java
@@ -38,6 +38,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import okio.Buffer;
+import okio.BufferedSink;
 import org.junit.Ignore;
 import org.junit.Test;
 import retrofit2.helpers.NullObjectConverterFactory;
@@ -3051,6 +3052,64 @@ public final class RequestFactoryTest {
     RequestBody body = RequestBody.create(TEXT_PLAIN, "hi");
     Request request = buildRequest(Example.class, body);
     assertThat(request.body().contentType().toString()).isEqualTo("text/not-plain");
+  }
+
+  @Test
+  public void contentTypeAnnotationHeaderPreservesOneShot() {
+    class Example {
+      @POST("/") //
+      @Headers("Content-Type: text/not-plain") //
+      Call<ResponseBody> method(@Body RequestBody body) {
+        return null;
+      }
+    }
+    RequestBody body =
+        new RequestBody() {
+          @Override
+          public MediaType contentType() {
+            return TEXT_PLAIN;
+          }
+
+          @Override
+          public void writeTo(BufferedSink sink) throws IOException {}
+
+          @Override
+          public boolean isOneShot() {
+            return true;
+          }
+        };
+
+    Request request = buildRequest(Example.class, body);
+    assertThat(request.body().isOneShot()).isTrue();
+  }
+
+  @Test
+  public void contentTypeAnnotationHeaderPreservesDuplex() {
+    class Example {
+      @POST("/") //
+      @Headers("Content-Type: text/not-plain") //
+      Call<ResponseBody> method(@Body RequestBody body) {
+        return null;
+      }
+    }
+    RequestBody body =
+        new RequestBody() {
+          @Override
+          public MediaType contentType() {
+            return TEXT_PLAIN;
+          }
+
+          @Override
+          public void writeTo(BufferedSink sink) throws IOException {}
+
+          @Override
+          public boolean isDuplex() {
+            return true;
+          }
+        };
+
+    Request request = buildRequest(Example.class, body);
+    assertThat(request.body().isDuplex()).isTrue();
   }
 
   @Test

--- a/retrofit/src/main/java/retrofit2/RequestBuilder.java
+++ b/retrofit/src/main/java/retrofit2/RequestBuilder.java
@@ -291,6 +291,16 @@ final class RequestBuilder {
     }
 
     @Override
+    public boolean isOneShot() {
+      return delegate.isOneShot();
+    }
+
+    @Override
+    public boolean isDuplex() {
+      return delegate.isDuplex();
+    }
+
+    @Override
     public void writeTo(BufferedSink sink) throws IOException {
       delegate.writeTo(sink);
     }


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.

## Summary

Preserve `RequestBody.isOneShot()` and `isDuplex()` when Retrofit overrides a request body's `Content-Type`.

## Details

`ContentTypeOverridingRequestBody` previously delegated `contentType()`, `contentLength()`, and `writeTo()`, but not `isOneShot()` or `isDuplex()`. As a result, wrapping a request body changed either flag back to OkHttp's default `false`.

This change delegates both methods to the wrapped request body and adds regression tests for each behavior.

## Tests

- `./gradlew :retrofit:java-test:testJdk17`