### PR TITLE
Add an optional marker interface to keep empty Retrofit services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Add explicit keep rules for RxJava `Result` types to prevent their generic information from being removed.
  - Add `allowoptimization` flags for most kept types.
  - Add `Invocation.annotationUrl` which returns the original URL from the method annotation.
+ - Add an optional `RetrofitService` marker interface to keep service interfaces available after R8 shrinking, even when they have no remaining HTTP methods.
 
 **Changed**
 

--- a/retrofit/java-test/build.gradle
+++ b/retrofit/java-test/build.gradle
@@ -28,6 +28,11 @@ tasks.withType(JavaCompile).configureEach {
     // Wire directly to the test source set outputs for proper task dependencies.
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
+
+    // Run one JDK's test worker at a time to avoid Gradle worker bootstrap failures.
+    if (majorVersion > 8) {
+      mustRunAfter("testJdk${majorVersion - 1}")
+    }
   }
   tasks.named("check").configure {
     dependsOn(jdkTest)

--- a/retrofit/src/main/java/retrofit2/RetrofitService.java
+++ b/retrofit/src/main/java/retrofit2/RetrofitService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Retrofit Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2;
+
+/**
+ * Optional marker interface that keeps a Retrofit service available after R8 shrinking.
+ * <p>
+ * Extend this interface to prevent R8 from removing or merging a service interface, even if it
+ * declares no HTTP methods or all its methods are removed as unused. The interface remains
+ * available for {@link Retrofit#create}, while unused methods can still be removed.
+ *
+ * <pre><code>
+ * public interface TestService extends RetrofitService {}
+ *
+ * TestService testService = retrofit.create(TestService.class);
+ * </code></pre>
+ */
+public interface RetrofitService {}

--- a/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+++ b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
@@ -35,6 +35,9 @@
 -if interface * { @retrofit2.http.* <methods>; }
 -keep,allowobfuscation interface * extends <1>
 
+# Keep marked services even when they have no remaining HTTP methods.
+-keep,allowobfuscation interface * extends retrofit2.RetrofitService
+
 # With R8 full mode generic signatures are stripped for classes that are not
 # kept. Suspend functions are wrapped in continuations where the type argument
 # is used.


### PR DESCRIPTION
Fixes #4295 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
